### PR TITLE
Relax the NumPy and hence AstroPy range limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ language: python
 matrix:
   include:
     - python: 3.7
-      env: NUMPY=1.15
+      env: NUMPY=1.18
 
 before_install:
   - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda3.sh

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.rst', 'rt') as fh:
     long_description = fh.read()
 
 setup(name='deproject',
-      version='0.2.0',
+      version='0.2.1',
       license='BSD',
       description='Sherpa deprojection package (X-ray analysis of Galaxy Clusters, Groups, and Galaxies)',
       keywords='deprojection xray 3d 2d plasma Astrophysics onion',
@@ -23,24 +23,9 @@ setup(name='deproject',
       packages=find_packages('src'),
       package_dir={'': 'src'},
 
-      # NOTE:
-      #  CIAO 4.11 comes with NumPy 1.12.1, but AstroPy 3.1 requires
-      #  NumPy >= 1.13.1, so add the restriction here.
-      #
-      #  This is restrictive for standalone Sherpa users, but it
-      #  requires a *lot* of effort to build the needed XSPEC model
-      #  support into Sherpa, so assume that the majority of use
-      #  cases will be installing into CIAO.
-      #
-      # SciPy may be needed. If users specify the angular-diameter
-      # distance to the source, or use a cosmology that does not
-      # use SciPy interpolation then SciPy is not needed. However,
-      # this may only be known about after doing a fit, which is
-      # annoying, so force SciPy on all users.
-      #
       setup_requires=['pytest-runner'],
       tests_require=['pytest'],
-      install_requires=['sherpa', 'astropy<3.1', 'scipy'],
+      install_requires=['sherpa', 'astropy', 'scipy'],
 
       python_requires='~=3.5',
 


### PR DESCRIPTION
With CIAO 4.12 now available in conda I feel it's safe to remove
the NumPy / AstroPy restriction.

This still uses the standalone 4.11.1 version. It could be updated
to use CIAO 4.12, which would be good because we could include XSPEC
tests, but the runtime would be longer (as significantly more to be
downloaded). Note that Sherpa standalone 4.12.0 should be being
released soon.